### PR TITLE
doc(dbt): Apple App Source README edited for Fivetran style

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Fivetran offers the ability for you to orchestrate your dbt project through [Fiv
 
 # 🔍 Does this package have dependencies?
 This dbt package is dependent on the following dbt packages. For more information on the following packages, refer to the [dbt hub](https://hub.getdbt.com/) site.
-> IMPORTANT: If you have any of these dependent packages in your own `packages.yml` file, we highly recommend that you remove them to avoid package version conflicts.
+> IMPORTANT: If you have any of these dependent packages in your own `packages.yml` file, we highly recommend that you remove them to avoid package version conflicts. 
 ```yml
 packages:
     - package: fivetran/fivetran_utils


### PR DESCRIPTION

I made an error in my original edit. I simply committed the changes I made without creating a PR. However, I had already made sure to note some discrepancies between the previous version of the README and the new standard for READMEs.

I compared the Apple App Source README with the standard established in the following PRs:

- https://github.com/fivetran/dbt_github_source/pull/24/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

- https://github.com/fivetran/dbt_github/pull/33/files

However, there are some portions of the original PR that are not present in the new standard, even though they seem essential for the README. I marked these with (???). For example:

![2022-05-12_21-44-51](https://user-images.githubusercontent.com/86319365/168214706-3c1e026a-8d65-462b-ba60-3fda6e0b2011.png)

![2022-05-12_21-45-05](https://user-images.githubusercontent.com/86319365/168214752-de018775-eb06-4a5a-83b4-8e9de7e861f8.png)

The other excluded portion of the original README seems like it would be essential to the new standard, but I can't seem to find it in the new standard. I'd greatly appreciate clarification on its presence:

![2022-05-12_21-58-21](https://user-images.githubusercontent.com/86319365/168214804-643f0e0a-75af-4239-8356-a3089efb9589.png)

Lastly. there is a section of the new standard that is not present at all in the old README, I marked it with (!!!):

![2022-05-12_21-46-35](https://user-images.githubusercontent.com/86319365/168214842-915f5449-87c2-4d8f-b12b-aa9b2c1596f9.png)

